### PR TITLE
Store data in XDG_DATA_HOME rather than the current dir on Linux

### DIFF
--- a/core/src/locations.cpp
+++ b/core/src/locations.cpp
@@ -15,7 +15,7 @@
 #include "data/data.h"
 #include "logger.h"
 
-QString osxWritableDirectory()
+QString unixWritableDirectory()
 {
     auto sep = QDir::separator();
 
@@ -35,9 +35,9 @@ Locations::Locations(const Data& data)
 {
     qDebug("Initializing path.");
 
-#if defined(Q_OS_OSX)
+#if defined(Q_OS_OSX) || defined(Q_OS_UNIX)
 
-    QDir appPath = QDir(osxWritableDirectory() + QDir::separator() + data.applicationSecret().mid(0, 8));
+    QDir appPath = QDir(unixWritableDirectory() + QDir::separator() + data.applicationSecret().mid(0, 8));
 
     if (!appPath.exists())
     {
@@ -87,8 +87,8 @@ QString Locations::currentDirPath() const
 
 QString Locations::logFilePath()
 {
-#if defined(Q_OS_OSX)
-    return QDir(osxWritableDirectory()).filePath(Config::logFileName);
+#if defined(Q_OS_OSX) || defined(Q_OS_UNIX)
+    return QDir(unixWritableDirectory()).filePath(Config::logFileName);
 #else
     return QDir(applicationDirPath()).filePath(Config::logFileName);
 #endif


### PR DESCRIPTION
The current method of storing data in the same directory that contains the executable is very limiting and unidiomatic on Linux, binaries are generally stored into read-only directories (from the user perspective), see e.g. the Packaging Standards of [Arch Linux](https://wiki.archlinux.org/index.php/Arch_package_guidelines#Directories).

After looking at your code, I saw that you already rely on a recommended way of detecting the storage directory as `QStandardPaths::GenericDataLocation`, but only for OS X.
Simply enabling this behaviour also for Linux makes the Launcher/Patcher write to `$XDG_DATA_HOME`, which is [the preferred location for user-writable application data](https://wiki.archlinux.org/index.php/XDG_Base_Directory#User_directories).